### PR TITLE
Add lacking output tabulation

### DIFF
--- a/lib/workflow-dispatch.js
+++ b/lib/workflow-dispatch.js
@@ -34,8 +34,8 @@ export async function dispatch(
   console.info(
     `dispatching workflow event:\n` +
       `\trepo: ${owner}/${repo}\n` +
-      `\workflow_id: ${workflowId}\n` +
-      `\ref: ${ref}\n` +
+      `\tworkflow_id: ${workflowId}\n` +
+      `\tref: ${ref}\n` +
       `\tupstream_ref: ${upstreamRef}\n` +
       `\tenvironment: ${environment}\n` +
       `\tupstream_builds: ${upstreamBuilds}`


### PR DESCRIPTION
Two of the lines in the console output for workflow dispatch were
missing tabulation.

Note: After merging changes to master it is required to update code of
the keep-network/notify-workflow-completed action in order to see the
changes being applied in workflows ussing this action.