### PR TITLE
Change the default value of `environment` input to `ropsten`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,7 @@ on:
       environment:
         description: 'The environment to run the build for'
         required: false
-        default: 'dev'
+        default: 'ropsten'
       upstream_builds:
         description: 'Upstream builds, if empty runs a default workflow'
         required: false


### PR DESCRIPTION
Value changed, as currently `ropsten` is the only environment on which
our CI process supports deployment / contract migration.