### PR TITLE
Update the name of workflow for `keep-ecdsa` module

### DIFF
--- a/config/config.json
+++ b/config/config.json
@@ -20,7 +20,7 @@
             ]
         },
         "github.com/keep-network/keep-ecdsa": {
-            "workflow": "client-ethereum.yml",
+            "workflow": "client.yml",
             "downstream": [
                 "github.com/keep-network/tbtc/solidity"
             ]


### PR DESCRIPTION
We've changed the name of the `keep-ecdsa`'s `client-ethereum.yml`
workflow to `client.yml`. We need to reflect that change in the CI
config.