### PR TITLE
Add building of coverage-pools module to the CI process

### DIFF
--- a/config/config.json
+++ b/config/config.json
@@ -28,8 +28,14 @@
         "github.com/keep-network/tbtc/solidity": {
             "workflow": "contracts.yml",
             "downstream": [
-                "github.com/keep-network/keep-core/dashboard",
+                "github.com/keep-network/coverage-pools",
                 "github.com/keep-network/tbtc.js"
+            ]
+        },
+        "github.com/keep-network/coverage-pools": {
+            "workflow": "contracts.yml",
+            "downstream": [
+                "github.com/keep-network/keep-core/dashboard"
             ]
         },
         "github.com/keep-network/keep-core/dashboard": {


### PR DESCRIPTION
We are adding new functionality of coverage pools to the Keep Network.
The contracts required for its support are stored in the
`covaragage-pools` repo and deployed thanks to the
`coverage-pools/.github/workflows/contracts.yml` workflow. We need to
incorporate that workflow in our CI process - we're doing that by
adding building of the `coverage-pools` module to the
`ci/config/config.json`. The module will be built after the
`tbtc/solidity` and before the `keep-core/dashboard`, because it
requires address of the `TBTC_DEPOSIT_TOKEN_ADDRESS` and
`TBTC_TOKEN_ADDRESS` contracts and because the module is needed for
successful building of the Token Dashboard.