### PR TITLE
Incorporate workflow building tbtc-v2

### DIFF
--- a/actions/notify-workflow-completed/dist/f3fa45b9cb98a33240a4.json
+++ b/actions/notify-workflow-completed/dist/f3fa45b9cb98a33240a4.json
@@ -28,6 +28,12 @@
         "github.com/keep-network/tbtc/solidity": {
             "workflow": "contracts.yml",
             "downstream": [
+                "github.com/keep-network/tbtc-v2/solidity"
+            ]
+        },
+        "github.com/keep-network/tbtc-v2/solidity": {
+            "workflow": "contracts.yml",
+            "downstream": [
                 "github.com/keep-network/keep-ecdsa/initcontainer"
             ]
         },

--- a/actions/notify-workflow-completed/dist/main.js
+++ b/actions/notify-workflow-completed/dist/main.js
@@ -16,7 +16,7 @@
 /***/ ((module, __unused_webpack_exports, __webpack_require__) => {
 
 "use strict";
-eval("module.exports = __webpack_require__.p + \"d9b310691f5a364207e5.json\";\n\n//# sourceURL=webpack://@keep-network/notify-workflow-completed/./node_modules/@keep-network/ci/config/config.json?");
+eval("module.exports = __webpack_require__.p + \"f3fa45b9cb98a33240a4.json\";\n\n//# sourceURL=webpack://@keep-network/notify-workflow-completed/./node_modules/@keep-network/ci/config/config.json?");
 
 /***/ }),
 

--- a/actions/run-workflow/dist/f3fa45b9cb98a33240a4.json
+++ b/actions/run-workflow/dist/f3fa45b9cb98a33240a4.json
@@ -28,6 +28,12 @@
         "github.com/keep-network/tbtc/solidity": {
             "workflow": "contracts.yml",
             "downstream": [
+                "github.com/keep-network/tbtc-v2/solidity"
+            ]
+        },
+        "github.com/keep-network/tbtc-v2/solidity": {
+            "workflow": "contracts.yml",
+            "downstream": [
                 "github.com/keep-network/keep-ecdsa/initcontainer"
             ]
         },

--- a/actions/run-workflow/dist/main.js
+++ b/actions/run-workflow/dist/main.js
@@ -16,7 +16,7 @@
 /***/ ((module, __unused_webpack_exports, __webpack_require__) => {
 
 "use strict";
-eval("module.exports = __webpack_require__.p + \"d9b310691f5a364207e5.json\";\n\n//# sourceURL=webpack://@keep-network/run-workflow/./node_modules/@keep-network/ci/config/config.json?");
+eval("module.exports = __webpack_require__.p + \"f3fa45b9cb98a33240a4.json\";\n\n//# sourceURL=webpack://@keep-network/run-workflow/./node_modules/@keep-network/ci/config/config.json?");
 
 /***/ }),
 

--- a/actions/upstream-builds-query/dist/f3fa45b9cb98a33240a4.json
+++ b/actions/upstream-builds-query/dist/f3fa45b9cb98a33240a4.json
@@ -28,6 +28,12 @@
         "github.com/keep-network/tbtc/solidity": {
             "workflow": "contracts.yml",
             "downstream": [
+                "github.com/keep-network/tbtc-v2/solidity"
+            ]
+        },
+        "github.com/keep-network/tbtc-v2/solidity": {
+            "workflow": "contracts.yml",
+            "downstream": [
                 "github.com/keep-network/keep-ecdsa/initcontainer"
             ]
         },

--- a/actions/upstream-builds-query/dist/main.cjs
+++ b/actions/upstream-builds-query/dist/main.cjs
@@ -16,7 +16,7 @@
 /***/ ((module, __unused_webpack_exports, __webpack_require__) => {
 
 "use strict";
-eval("module.exports = __webpack_require__.p + \"d9b310691f5a364207e5.json\";\n\n//# sourceURL=webpack://@keep-network/upstream-builds-query/./node_modules/@keep-network/ci/config/config.json?");
+eval("module.exports = __webpack_require__.p + \"f3fa45b9cb98a33240a4.json\";\n\n//# sourceURL=webpack://@keep-network/upstream-builds-query/./node_modules/@keep-network/ci/config/config.json?");
 
 /***/ }),
 

--- a/config/config.json
+++ b/config/config.json
@@ -28,6 +28,12 @@
         "github.com/keep-network/tbtc/solidity": {
             "workflow": "contracts.yml",
             "downstream": [
+                "github.com/keep-network/tbtc-v2/solidity"
+            ]
+        },
+        "github.com/keep-network/tbtc-v2/solidity": {
+            "workflow": "contracts.yml",
+            "downstream": [
                 "github.com/keep-network/keep-ecdsa/initcontainer"
             ]
         },


### PR DESCRIPTION
We're adding new module (`tbtc-v2/solidity`) to the CI flow
configuration. As the module is dependant on `tbtc/solidity` and may be
in the future needed for `keep-ecdsa/initcontainer`, we're executing it
between those two modules.

Ref:
https://github.com/keep-network/tbtc-v2/pull/29

TODO **after** merging:

- [ ] update the `v1` tag