### PR TITLE
Renaming workflow name for allthekeeps

### DIFF
--- a/config/config.json
+++ b/config/config.json
@@ -56,7 +56,7 @@
             ]
         },
         "github.com/keep-network/allthekeeps": {
-            "workflow": "allthekeeps-ropsten.yml",
+            "workflow": "allthekeeps-testnet.yml",
             "downstream": []
         },
         "github.com/keep-network/tbtc-dapp": {


### PR DESCRIPTION
In [allthekeeps](https://github.com/keep-network/allthekeeps) the workflow was renamed to `allthekeeps-testnet.yml`. Changes should be reflected here in the config as well.