### PR TITLE
Updating references to solidity-v1

### DIFF
--- a/config/config.json
+++ b/config/config.json
@@ -1,7 +1,7 @@
 {
-    "defaultModule": "github.com/keep-network/keep-core/solidity",
+    "defaultModule": "github.com/keep-network/keep-core/solidity-v1",
     "modules": {
-        "github.com/keep-network/keep-core/solidity": {
+        "github.com/keep-network/keep-core/solidity-v1": {
             "workflow": "contracts.yml",
             "downstream": [
                 "github.com/keep-network/keep-core"


### PR DESCRIPTION
The v1 of the random beacon will be placed in `solidity-v1` dir. v2 will be
developed in `/solidity` dir instead. We need to update the reference.