### PR TITLE
Replace Meercode links with links to filtered GH Actions views

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,9 +72,30 @@ code.
 The following tools can be used to monitor state of the code and deployments:
 * [AllTheKeeps for Ropsten](https://allthekeeps.test.keep.network/deposits)
 * [Keep Clients Summary](https://monitoring.test.keep.network/d/3r-BohOMz/keep-clients-summary?orgId=1&refresh=30s)
+<!-- Meercode has stopped displaying results when Organization or Repository
+filter is applied. I reported the issue via the Feedback tool. Until issue gets
+fixed, I'm commenting out the links to the Meercode dashboards. Instead, I'm
+adding links to GH Actions filters that may be useful.
 * Meercode Dashboards with GitHub Actions results:
   - [Relay request submitter / Testnet](https://meercode.io/public/list/af470c2ebc0da4a0b0cce2589660781e:f385a85f1b9ca5b44b35b1d61405b8569c4664f6cf41a8e71283d45ff4ff61b8f20f11dbb75d767c51a809ccd2ea06af)
   - [E2E and other scheduled tests in `local-setup`](https://meercode.io/public/list/07e8ed6fc354cb325b817626d09f6dce:c275abc3348031a1db35d79bd48533492d2ece50ae1f6cc696285b2064e33e8a35656aeaba4375687c8491e0fa44cb32)
   - [Daily builds and unit tests in `keep-core`](https://meercode.io/public/list/8658c17fc7593705fa105554536944eb:e630b20f8cb551d86d965e7134c96588e0959d8a66c9c74a92d913e3884d66f5e72cb4168d59fe0b78e17a1efebaec11/)
   - [Daily builds and unit tests in other repositories](https://meercode.io/public/list/996bf02d60c51e6ec3143e910a2f2afb:3d43f754b84d6a07209a882c825e273284b07de775fdcb2503e5d425f034c57c920ba8175aa1d7fff01cc6159ac9f80f)
-  - [Deployment on Ropsten](https://meercode.io/public/list/41935b8f5ffcabfd0c0d63412547d720:1c3901d698c5c033914774f1cc5b8ffed254357a89c7a59b20f0c909db2141aa3e23b7a2080036f914c66f3f5cd69fdf)
+  - [Deployment on Ropsten](https://meercode.io/public/list/41935b8f5ffcabfd0c0d63412547d720:1c3901d698c5c033914774f1cc5b8ffed254357a89c7a59b20f0c909db2141aa3e23b7a2080036f914c66f3f5cd69fdf) -->
+* GitHub Actions workflows triggered by a cron:
+  - [local-setup](https://github.com/keep-network/local-setup/actions?query=event%3Aschedule)
+  - [keep-core](https://github.com/keep-network/keep-core/actions?query=event%3Aschedule)
+  - [keep-ecdsa](https://github.com/keep-network/keep-ecdsa/actions?query=event%3Aschedule)
+  - [tbtc](https://github.com/keep-network/tbtc/actions?query=event%3Aschedule)
+  - [tbtc-v2](https://github.com/keep-network/tbtc-v2/actions?query=event%3Aschedule)
+  - [coverage-pools](https://github.com/keep-network/coverage-pools/actions?query=event%3Aschedule)
+  - [tbtc.js](https://github.com/keep-network/tbtc.js/actions?query=event%3Aschedule)
+  - [tbtc-dapp](https://github.com/keep-network/tbtc-dapp/actions?query=event%3Aschedule)
+* GitHub Actions workflows triggered manually:
+  - [keep-core](https://github.com/keep-network/keep-core/actions?query=event%3Aworkflow_dispatch)
+  - [keep-ecdsa](https://github.com/keep-network/keep-ecdsa/actions?query=event%3Aworkflow_dispatch)
+  - [tbtc](https://github.com/keep-network/tbtc/actions?query=event%3Aworkflow_dispatch)
+  - [tbtc-v2](https://github.com/keep-network/tbtc-v2/actions?query=event%3Aworkflow_dispatch)
+  - [coverage-pools](https://github.com/keep-network/tbtc-v2/actions?query=event%3Aworkflow_dispatch)
+  - [tbtc.js](https://github.com/keep-network/tbtc.js/actions?query=event%3Aworkflow_dispatch)
+  - [tbtc-dapp](https://github.com/keep-network/tbtc-dapp/actions?query=event%3Aworkflow_dispatch)


### PR DESCRIPTION
We've been using Meercode tool to gather information about GH Actions
workflows displayed by a cron and by workflow_dispatch events. The tool,
although having some limitations, allowed us to present on one dashboard
statuses of workflows from different repositories, which has been useful
during our daily examination of tests run at night or during Ropsten
deployment.
Unfortunatelly, recently Meercode has stopped displaying results when
Organization or Repository filter is applied (we did use those filters
in all our custom views). I reported the issue to the tool creators via the
Feedback tool. Until issue gets fixed, I'm commenting out the links to the
Meercode dashboards. Instead, I'm adding links to GH Actions filters that
may be useful to quicly access information that's needed for monitoring.