### PR TITLE
Update meercode links

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,6 @@ The following tools can be used to monitor state of the code and deployments:
 * [Keep Clients Summary](https://monitoring.test.keep.network/d/3r-BohOMz/keep-clients-summary?orgId=1&refresh=30s)
 * Meercode Dashboards with GitHub Actions results:
   - [Relay request submitter / Testnet](https://meercode.io/public/list/af470c2ebc0da4a0b0cce2589660781e:f385a85f1b9ca5b44b35b1d61405b8569c4664f6cf41a8e71283d45ff4ff61b8f20f11dbb75d767c51a809ccd2ea06af)
-  - [E2E and other scheduled tests in `local-setup`](https://meercode.io/public/list/07e8ed6fc354cb325b817626d09f6dce:c275abc3348031a1db35d79bd48533492d2ece50ae1f6cc696285b2064e33e8a35656aeaba4375687c8491e0fa44cb32)
-  - [Daily builds and unit tests in `keep-core`](https://meercode.io/public/list/8658c17fc7593705fa105554536944eb:e630b20f8cb551d86d965e7134c96588e0959d8a66c9c74a92d913e3884d66f5e72cb4168d59fe0b78e17a1efebaec11/)
-  - [Daily builds and unit tests in other repositories](https://meercode.io/public/list/996bf02d60c51e6ec3143e910a2f2afb:3d43f754b84d6a07209a882c825e273284b07de775fdcb2503e5d425f034c57c920ba8175aa1d7fff01cc6159ac9f80f)
+  - [E2E tests in `local-setup`](https://meercode.io/public/list/acef9c5954837d43d0249f46d8c38306:2f621d7a4bbef9f85bb4430a88ead6d456ebdadbb7df6fb51a0aab7c10ec457031e7b0f0ee6b0408c7654a3a51057998)
+  - [Daily builds and unit tests](https://meercode.io/public/list/053530dd02546314c4091f19203a8094:89d01b2400180e5f00f4ae237a4fc3abcce4ed4d4598c0a73c207403d3759e653d5a65a094d520105d311545070beeee)
   - [Deployment on Ropsten](https://meercode.io/public/list/41935b8f5ffcabfd0c0d63412547d720:1c3901d698c5c033914774f1cc5b8ffed254357a89c7a59b20f0c909db2141aa3e23b7a2080036f914c66f3f5cd69fdf)


### PR DESCRIPTION
We've been using Meercode tool to gather information about GH Actions
workflows triggered by a cron and by workflow_dispatch events, which
has been useful during our daily examination of tests run at night or
during Ropsten deployment.
There was a bug in meercode that was limitig functionality of lists
filtering, which forced us to have non-optimal configuration of the
views. Now the bug got fixed and we are able to present all workflows
with the daily tests in one view.