### PR TITLE
Update Meercode link

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,5 +75,5 @@ The following tools can be used to monitor state of the code and deployments:
 * Meercode Dashboards with GitHub Actions results:
   - [Relay request submitter / Testnet](https://meercode.io/public/list/af470c2ebc0da4a0b0cce2589660781e:f385a85f1b9ca5b44b35b1d61405b8569c4664f6cf41a8e71283d45ff4ff61b8f20f11dbb75d767c51a809ccd2ea06af)
   - [E2E tests in `local-setup`](https://meercode.io/public/list/acef9c5954837d43d0249f46d8c38306:2f621d7a4bbef9f85bb4430a88ead6d456ebdadbb7df6fb51a0aab7c10ec457031e7b0f0ee6b0408c7654a3a51057998)
-  - [Daily builds and unit tests](https://meercode.io/public/list/7d25a53902f2ccecdbb2ee6ce17bb539:d820851c40ae4b0a0086b92864145eb1f15802ce5cc6c17bb1505e1e895fe8fa618e7f4ce90f7709ba5d0e7bf06ebfd2)
+  - [Daily builds and unit tests](https://meercode.io/public/list/a35b93b575273416124a32f8cd9d1d5f:60fde75491810d92b496eed2bb3ce55ec4124ca10a75cb4273dcad863e8f4d94b51fbbbe4cb07ecbfb40fc4edef71464)
   - [Deployment on Ropsten](https://meercode.io/public/list/41935b8f5ffcabfd0c0d63412547d720:1c3901d698c5c033914774f1cc5b8ffed254357a89c7a59b20f0c909db2141aa3e23b7a2080036f914c66f3f5cd69fdf)


### PR DESCRIPTION
Recently we've renamed a `tbtc-ts` workflow in `tbtc-v2` repository to
`TypeScript bindings`.
This means we needed to update the `Daily builds and unit tests`
Meercode view to include the renamed workflow. Updated view is available
under new link, which we're docummenting here in README.