### PR TITLE
Use `v2` of `run-workflow` action in the Main workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Invoke downstream workflows
-        uses: keep-network/ci/actions/run-workflow@v1
+        uses: keep-network/ci/actions/run-workflow@v2
         env:
           GITHUB_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
In PR #28 we modified the order in which modules get executed as part of
the CI flow. New modules were added, old removed, etc. We tagged the new
config with `v2` tag, which results in need for calling `v2`-tagged
actions in our CI. We already updated the workflows building each
module in previous code changes, but we did not update the `Main`
workflow in the `ci` project - and this workflow is responsible for
triggering new module once the previous (upstream) one finishes
execution. Now we're adding that missing update.

Ref:
https://github.com/keep-network/ci/pull/28