### PR TITLE
Shorten the names of modules

### DIFF
--- a/actions/notify-workflow-completed/dist/config.json
+++ b/actions/notify-workflow-completed/dist/config.json
@@ -4,22 +4,22 @@
         "github.com/threshold-network/solidity-contracts": {
             "workflow": "contracts.yml",
             "downstream": [
-                "github.com/keep-network/keep-core/solidity/random-beacon"
+                "github.com/keep-network/keep-core/random-beacon"
             ]
         },
-        "github.com/keep-network/keep-core/solidity/random-beacon": {
+        "github.com/keep-network/keep-core/random-beacon": {
             "workflow": "contracts-random-beacon.yml",
             "downstream": [
-                "github.com/keep-network/keep-core/solidity/ecdsa"
+                "github.com/keep-network/keep-core/ecdsa"
             ]
         },
-        "github.com/keep-network/keep-core/solidity/ecdsa": {
+        "github.com/keep-network/keep-core/ecdsa": {
             "workflow": "contracts-ecdsa.yml",
             "downstream": [
-                "github.com/keep-network/tbtc-v2/solidity"
+                "github.com/keep-network/tbtc-v2"
             ]
         },
-        "github.com/keep-network/tbtc-v2/solidity": {
+        "github.com/keep-network/tbtc-v2": {
             "workflow": "contracts.yml",
             "downstream": []
         }

--- a/actions/run-workflow/dist/config.json
+++ b/actions/run-workflow/dist/config.json
@@ -4,22 +4,22 @@
         "github.com/threshold-network/solidity-contracts": {
             "workflow": "contracts.yml",
             "downstream": [
-                "github.com/keep-network/keep-core/solidity/random-beacon"
+                "github.com/keep-network/keep-core/random-beacon"
             ]
         },
-        "github.com/keep-network/keep-core/solidity/random-beacon": {
+        "github.com/keep-network/keep-core/random-beacon": {
             "workflow": "contracts-random-beacon.yml",
             "downstream": [
-                "github.com/keep-network/keep-core/solidity/ecdsa"
+                "github.com/keep-network/keep-core/ecdsa"
             ]
         },
-        "github.com/keep-network/keep-core/solidity/ecdsa": {
+        "github.com/keep-network/keep-core/ecdsa": {
             "workflow": "contracts-ecdsa.yml",
             "downstream": [
-                "github.com/keep-network/tbtc-v2/solidity"
+                "github.com/keep-network/tbtc-v2"
             ]
         },
-        "github.com/keep-network/tbtc-v2/solidity": {
+        "github.com/keep-network/tbtc-v2": {
             "workflow": "contracts.yml",
             "downstream": []
         }

--- a/actions/upstream-builds-query/dist/config.json
+++ b/actions/upstream-builds-query/dist/config.json
@@ -4,22 +4,22 @@
         "github.com/threshold-network/solidity-contracts": {
             "workflow": "contracts.yml",
             "downstream": [
-                "github.com/keep-network/keep-core/solidity/random-beacon"
+                "github.com/keep-network/keep-core/random-beacon"
             ]
         },
-        "github.com/keep-network/keep-core/solidity/random-beacon": {
+        "github.com/keep-network/keep-core/random-beacon": {
             "workflow": "contracts-random-beacon.yml",
             "downstream": [
-                "github.com/keep-network/keep-core/solidity/ecdsa"
+                "github.com/keep-network/keep-core/ecdsa"
             ]
         },
-        "github.com/keep-network/keep-core/solidity/ecdsa": {
+        "github.com/keep-network/keep-core/ecdsa": {
             "workflow": "contracts-ecdsa.yml",
             "downstream": [
-                "github.com/keep-network/tbtc-v2/solidity"
+                "github.com/keep-network/tbtc-v2"
             ]
         },
-        "github.com/keep-network/tbtc-v2/solidity": {
+        "github.com/keep-network/tbtc-v2": {
             "workflow": "contracts.yml",
             "downstream": []
         }

--- a/config/config.json
+++ b/config/config.json
@@ -4,22 +4,22 @@
         "github.com/threshold-network/solidity-contracts": {
             "workflow": "contracts.yml",
             "downstream": [
-                "github.com/keep-network/keep-core/solidity/random-beacon"
+                "github.com/keep-network/keep-core/random-beacon"
             ]
         },
-        "github.com/keep-network/keep-core/solidity/random-beacon": {
+        "github.com/keep-network/keep-core/random-beacon": {
             "workflow": "contracts-random-beacon.yml",
             "downstream": [
-                "github.com/keep-network/keep-core/solidity/ecdsa"
+                "github.com/keep-network/keep-core/ecdsa"
             ]
         },
-        "github.com/keep-network/keep-core/solidity/ecdsa": {
+        "github.com/keep-network/keep-core/ecdsa": {
             "workflow": "contracts-ecdsa.yml",
             "downstream": [
-                "github.com/keep-network/tbtc-v2/solidity"
+                "github.com/keep-network/tbtc-v2"
             ]
         },
-        "github.com/keep-network/tbtc-v2/solidity": {
+        "github.com/keep-network/tbtc-v2": {
             "workflow": "contracts.yml",
             "downstream": []
         }


### PR DESCRIPTION
Module name must consist of 3-4 parts separated by `/` char. We decided
to not reflect the project's repo path in the module name, just include
repo's name and name of the project.

TODO after the merge:

- [ ] tag the code with `v2` tag