### PR TITLE
Add modules building client and Token dashboard

### DIFF
--- a/actions/notify-workflow-completed/dist/config.json
+++ b/actions/notify-workflow-completed/dist/config.json
@@ -21,6 +21,18 @@
         },
         "github.com/keep-network/tbtc-v2": {
             "workflow": "contracts.yml",
+            "downstream": [
+                "github.com/keep-network/keep-core/client"
+            ]
+        },
+        "github.com/keep-network/keep-core/client": {
+            "workflow": "client.yml",
+            "downstream": [
+                "github.com/threshold-network/token-dashboard"
+            ]
+        },
+        "github.com/threshold-network/token-dashboard": {
+            "workflow": "dashboard-ci.yml",
             "downstream": []
         }
     }

--- a/actions/run-workflow/dist/config.json
+++ b/actions/run-workflow/dist/config.json
@@ -21,6 +21,18 @@
         },
         "github.com/keep-network/tbtc-v2": {
             "workflow": "contracts.yml",
+            "downstream": [
+                "github.com/keep-network/keep-core/client"
+            ]
+        },
+        "github.com/keep-network/keep-core/client": {
+            "workflow": "client.yml",
+            "downstream": [
+                "github.com/threshold-network/token-dashboard"
+            ]
+        },
+        "github.com/threshold-network/token-dashboard": {
+            "workflow": "dashboard-ci.yml",
             "downstream": []
         }
     }

--- a/actions/upstream-builds-query/dist/config.json
+++ b/actions/upstream-builds-query/dist/config.json
@@ -21,6 +21,18 @@
         },
         "github.com/keep-network/tbtc-v2": {
             "workflow": "contracts.yml",
+            "downstream": [
+                "github.com/keep-network/keep-core/client"
+            ]
+        },
+        "github.com/keep-network/keep-core/client": {
+            "workflow": "client.yml",
+            "downstream": [
+                "github.com/threshold-network/token-dashboard"
+            ]
+        },
+        "github.com/threshold-network/token-dashboard": {
+            "workflow": "dashboard-ci.yml",
             "downstream": []
         }
     }

--- a/config/config.json
+++ b/config/config.json
@@ -21,6 +21,18 @@
         },
         "github.com/keep-network/tbtc-v2": {
             "workflow": "contracts.yml",
+            "downstream": [
+                "github.com/keep-network/keep-core/client"
+            ]
+        },
+        "github.com/keep-network/keep-core/client": {
+            "workflow": "client.yml",
+            "downstream": [
+                "github.com/threshold-network/token-dashboard"
+            ]
+        },
+        "github.com/threshold-network/token-dashboard": {
+            "workflow": "dashboard-ci.yml",
             "downstream": []
         }
     }


### PR DESCRIPTION
We're ready to integrate new modules into the CI flow. We will build the
client after `tbtc-v2` contracts and Token dashboard after the
client.

TODO after the merge:

- [ ] tag the code with `v2` tag