### PR TITLE
Deploy client in parallel to dashboard

### DIFF
--- a/actions/notify-workflow-completed/dist/config.json
+++ b/actions/notify-workflow-completed/dist/config.json
@@ -22,14 +22,13 @@
         "github.com/keep-network/tbtc-v2": {
             "workflow": "contracts.yml",
             "downstream": [
-                "github.com/keep-network/keep-core/client"
+                "github.com/keep-network/keep-core/client",
+                "github.com/threshold-network/token-dashboard"
             ]
         },
         "github.com/keep-network/keep-core/client": {
             "workflow": "client.yml",
-            "downstream": [
-                "github.com/threshold-network/token-dashboard"
-            ]
+            "downstream": []
         },
         "github.com/threshold-network/token-dashboard": {
             "workflow": "dashboard-ci.yml",

--- a/actions/run-workflow/dist/config.json
+++ b/actions/run-workflow/dist/config.json
@@ -22,14 +22,13 @@
         "github.com/keep-network/tbtc-v2": {
             "workflow": "contracts.yml",
             "downstream": [
-                "github.com/keep-network/keep-core/client"
+                "github.com/keep-network/keep-core/client",
+                "github.com/threshold-network/token-dashboard"
             ]
         },
         "github.com/keep-network/keep-core/client": {
             "workflow": "client.yml",
-            "downstream": [
-                "github.com/threshold-network/token-dashboard"
-            ]
+            "downstream": []
         },
         "github.com/threshold-network/token-dashboard": {
             "workflow": "dashboard-ci.yml",

--- a/actions/upstream-builds-query/dist/config.json
+++ b/actions/upstream-builds-query/dist/config.json
@@ -22,14 +22,13 @@
         "github.com/keep-network/tbtc-v2": {
             "workflow": "contracts.yml",
             "downstream": [
-                "github.com/keep-network/keep-core/client"
+                "github.com/keep-network/keep-core/client",
+                "github.com/threshold-network/token-dashboard"
             ]
         },
         "github.com/keep-network/keep-core/client": {
             "workflow": "client.yml",
-            "downstream": [
-                "github.com/threshold-network/token-dashboard"
-            ]
+            "downstream": []
         },
         "github.com/threshold-network/token-dashboard": {
             "workflow": "dashboard-ci.yml",

--- a/config/config.json
+++ b/config/config.json
@@ -22,14 +22,13 @@
         "github.com/keep-network/tbtc-v2": {
             "workflow": "contracts.yml",
             "downstream": [
-                "github.com/keep-network/keep-core/client"
+                "github.com/keep-network/keep-core/client",
+                "github.com/threshold-network/token-dashboard"
             ]
         },
         "github.com/keep-network/keep-core/client": {
             "workflow": "client.yml",
-            "downstream": [
-                "github.com/threshold-network/token-dashboard"
-            ]
+            "downstream": []
         },
         "github.com/threshold-network/token-dashboard": {
             "workflow": "dashboard-ci.yml",


### PR DESCRIPTION
Previously the `token-dashboard` module was being built in CI flow after the
`client` module. But we don't need to wait for building of the client to build
dashboard, those jobs don't depend on each other. This means we can run them in
parallel.

TODO after the merge:

- [ ] tag the action with `v2`