### PR TITLE
Use actions running on `node16`

### DIFF
--- a/.github/workflows/load-env-variables.yml
+++ b/.github/workflows/load-env-variables.yml
@@ -19,7 +19,7 @@ jobs:
   load-env-variables-manual-test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Load environment variables
         uses: ./actions/load-env-variables

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,7 @@ jobs:
   run-release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Invoke downstream workflows
         uses: keep-network/ci/actions/run-workflow@v2

--- a/.github/workflows/tools.yml
+++ b/.github/workflows/tools.yml
@@ -10,12 +10,12 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - run: yarn install
       - run: yarn run test
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - run: yarn install
       - run: yarn run lint

--- a/.github/workflows/upstream-builds-query.yml
+++ b/.github/workflows/upstream-builds-query.yml
@@ -20,11 +20,11 @@ jobs:
     name: Verify committed dist directory
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           persist-credentials: false
 
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
           node-version: "12"
 
@@ -50,11 +50,11 @@ jobs:
   upstream-builds-query-unit-tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           persist-credentials: false
 
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
           node-version: "12"
 
@@ -65,7 +65,7 @@ jobs:
   upstream-builds-query-e2e-test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: ./actions/upstream-builds-query
         id: upstream-builds-query


### PR DESCRIPTION
Node 12 has been out of support since April 2022, as a result GitHub has started the deprecation process of Node 12 for GitHub Actions. They plan to migrate all actions to run on Node16 by Summer 2023. Some of the GH Marketplace actions that we've been using in our workflows were running on `node12`, but have already published new versions running on `node16`. We're updating those actions to the latest versions.

Read more on
https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.