### PR TITLE
Add `coverage-pools` module to the CI flow

### DIFF
--- a/actions/notify-workflow-completed/dist/config.json
+++ b/actions/notify-workflow-completed/dist/config.json
@@ -4,6 +4,12 @@
         "github.com/threshold-network/solidity-contracts": {
             "workflow": "contracts.yml",
             "downstream": [
+                "github.com/keep-network/coverage-pools"
+            ]
+        },
+        "github.com/keep-network/coverage-pools": {
+            "workflow": "contracts.yml",
+            "downstream": [
                 "github.com/keep-network/keep-core/random-beacon"
             ]
         },

--- a/actions/run-workflow/dist/config.json
+++ b/actions/run-workflow/dist/config.json
@@ -4,6 +4,12 @@
         "github.com/threshold-network/solidity-contracts": {
             "workflow": "contracts.yml",
             "downstream": [
+                "github.com/keep-network/coverage-pools"
+            ]
+        },
+        "github.com/keep-network/coverage-pools": {
+            "workflow": "contracts.yml",
+            "downstream": [
                 "github.com/keep-network/keep-core/random-beacon"
             ]
         },

--- a/actions/upstream-builds-query/dist/config.json
+++ b/actions/upstream-builds-query/dist/config.json
@@ -4,6 +4,12 @@
         "github.com/threshold-network/solidity-contracts": {
             "workflow": "contracts.yml",
             "downstream": [
+                "github.com/keep-network/coverage-pools"
+            ]
+        },
+        "github.com/keep-network/coverage-pools": {
+            "workflow": "contracts.yml",
+            "downstream": [
                 "github.com/keep-network/keep-core/random-beacon"
             ]
         },

--- a/config/config.json
+++ b/config/config.json
@@ -4,6 +4,12 @@
         "github.com/threshold-network/solidity-contracts": {
             "workflow": "contracts.yml",
             "downstream": [
+                "github.com/keep-network/coverage-pools"
+            ]
+        },
+        "github.com/keep-network/coverage-pools": {
+            "workflow": "contracts.yml",
+            "downstream": [
                 "github.com/keep-network/keep-core/random-beacon"
             ]
         },


### PR DESCRIPTION
We're ready to include the deploy of the `@keep-network/coverage-pools` contracts to the CI flow. We're placing the `github.com/keep-network/coverage-pools` module after the `github.com/threshold-network/solidity-contracts`, as coverage-pools have a dependency to the `threshold-network/solidity-contracts`, but not to any of the downstream modules.

TODO:
- [x] Create a PR in `coverage-pools` which updates the `Solidity` workflow to use the `v2` of the action (https://github.com/keep-network/coverage-pools/pull/231)
- [ ] Update the `v2` tag after the merge