### PR TITLE
Add `tbtc-v2.ts` module to the CI flow

### DIFF
--- a/actions/notify-workflow-completed/dist/config.json
+++ b/actions/notify-workflow-completed/dist/config.json
@@ -23,6 +23,12 @@
             "workflow": "contracts.yml",
             "downstream": [
                 "github.com/keep-network/keep-core/client",
+                "github.com/keep-network/tbtc-v2.ts"
+            ]
+        },
+        "github.com/keep-network/tbtc-v2.ts": {
+            "workflow": "typescript.yml",
+            "downstream": [
                 "github.com/threshold-network/token-dashboard"
             ]
         },

--- a/actions/run-workflow/dist/config.json
+++ b/actions/run-workflow/dist/config.json
@@ -23,6 +23,12 @@
             "workflow": "contracts.yml",
             "downstream": [
                 "github.com/keep-network/keep-core/client",
+                "github.com/keep-network/tbtc-v2.ts"
+            ]
+        },
+        "github.com/keep-network/tbtc-v2.ts": {
+            "workflow": "typescript.yml",
+            "downstream": [
                 "github.com/threshold-network/token-dashboard"
             ]
         },

--- a/actions/upstream-builds-query/dist/config.json
+++ b/actions/upstream-builds-query/dist/config.json
@@ -23,6 +23,12 @@
             "workflow": "contracts.yml",
             "downstream": [
                 "github.com/keep-network/keep-core/client",
+                "github.com/keep-network/tbtc-v2.ts"
+            ]
+        },
+        "github.com/keep-network/tbtc-v2.ts": {
+            "workflow": "typescript.yml",
+            "downstream": [
                 "github.com/threshold-network/token-dashboard"
             ]
         },

--- a/config/config.json
+++ b/config/config.json
@@ -23,6 +23,12 @@
             "workflow": "contracts.yml",
             "downstream": [
                 "github.com/keep-network/keep-core/client",
+                "github.com/keep-network/tbtc-v2.ts"
+            ]
+        },
+        "github.com/keep-network/tbtc-v2.ts": {
+            "workflow": "typescript.yml",
+            "downstream": [
                 "github.com/threshold-network/token-dashboard"
             ]
         },


### PR DESCRIPTION
We're ready to include the deploy of the `@keep-network/tbtc-v2.ts` to the CI flow. We're placing the `github.com/keep-network/tbtc-v2.ts` module after the `github.com/keep-network/tbtc-v2`, as `tbtc-v2.ts` has a dependency to the `tbtc-v2`, but not to any of the downstream modules.

![ci-stream-v8](https://user-images.githubusercontent.com/78352137/216953155-8f5b2d94-90e4-4b1c-92db-f0fa7e7e1809.png)

TODO after the merge:

- [ ] update `v2` tag

Ref:
https://github.com/keep-network/tbtc-v2/pull/522

