### PR TITLE
Add `tbtc-mg` module to the CI flow

### DIFF
--- a/actions/notify-workflow-completed/dist/config.json
+++ b/actions/notify-workflow-completed/dist/config.json
@@ -29,7 +29,8 @@
         "github.com/keep-network/tbtc-v2.ts": {
             "workflow": "typescript.yml",
             "downstream": [
-                "github.com/threshold-network/token-dashboard"
+                "github.com/threshold-network/token-dashboard",
+                "github.com/keep-network/tbtc-mg"
             ]
         },
         "github.com/keep-network/keep-core/client": {
@@ -38,6 +39,10 @@
         },
         "github.com/threshold-network/token-dashboard": {
             "workflow": "dashboard-ci.yml",
+            "downstream": []
+        },
+        "github.com/keep-network/tbtc-mg": {
+            "workflow": "maintainer.yml",
             "downstream": []
         }
     }

--- a/actions/run-workflow/dist/config.json
+++ b/actions/run-workflow/dist/config.json
@@ -29,7 +29,8 @@
         "github.com/keep-network/tbtc-v2.ts": {
             "workflow": "typescript.yml",
             "downstream": [
-                "github.com/threshold-network/token-dashboard"
+                "github.com/threshold-network/token-dashboard",
+                "github.com/keep-network/tbtc-mg"
             ]
         },
         "github.com/keep-network/keep-core/client": {
@@ -38,6 +39,10 @@
         },
         "github.com/threshold-network/token-dashboard": {
             "workflow": "dashboard-ci.yml",
+            "downstream": []
+        },
+        "github.com/keep-network/tbtc-mg": {
+            "workflow": "maintainer.yml",
             "downstream": []
         }
     }

--- a/actions/upstream-builds-query/dist/config.json
+++ b/actions/upstream-builds-query/dist/config.json
@@ -29,7 +29,8 @@
         "github.com/keep-network/tbtc-v2.ts": {
             "workflow": "typescript.yml",
             "downstream": [
-                "github.com/threshold-network/token-dashboard"
+                "github.com/threshold-network/token-dashboard",
+                "github.com/keep-network/tbtc-mg"
             ]
         },
         "github.com/keep-network/keep-core/client": {
@@ -38,6 +39,10 @@
         },
         "github.com/threshold-network/token-dashboard": {
             "workflow": "dashboard-ci.yml",
+            "downstream": []
+        },
+        "github.com/keep-network/tbtc-mg": {
+            "workflow": "maintainer.yml",
             "downstream": []
         }
     }

--- a/config/config.json
+++ b/config/config.json
@@ -29,7 +29,8 @@
         "github.com/keep-network/tbtc-v2.ts": {
             "workflow": "typescript.yml",
             "downstream": [
-                "github.com/threshold-network/token-dashboard"
+                "github.com/threshold-network/token-dashboard",
+                "github.com/keep-network/tbtc-mg"
             ]
         },
         "github.com/keep-network/keep-core/client": {
@@ -38,6 +39,10 @@
         },
         "github.com/threshold-network/token-dashboard": {
             "workflow": "dashboard-ci.yml",
+            "downstream": []
+        },
+        "github.com/keep-network/tbtc-mg": {
+            "workflow": "maintainer.yml",
             "downstream": []
         }
     }


### PR DESCRIPTION
We're ready to include the building of the `tbtc-mg` Docker image in the CI flow. We're placing the `github.com/keep-network/tbtc-mg` module after the `github.com/keep-network/tbtc-v2.ts`, as `tbtc-mg` has a dependency to the `tbtc-v2.ts`.

New structure:
![ci-stream-v9 excalidraw](https://user-images.githubusercontent.com/78352137/220328831-6e7a5873-0502-46bf-8a69-e7649a960aef.png)

TODO after the merge:

- [ ] update the `v2` tag
