### PR TITLE
Adding cross chain Arbitrum workflow

### DIFF
--- a/actions/notify-workflow-completed/dist/config.json
+++ b/actions/notify-workflow-completed/dist/config.json
@@ -29,7 +29,8 @@
             "workflow": "contracts.yml",
             "downstream": [
                 "github.com/keep-network/keep-core/client",
-                "github.com/keep-network/tbtc-v2.ts"
+                "github.com/keep-network/tbtc-v2.ts",
+                "github.com/keep-network/cross-chain/arbitrum"
             ]
         },
         "github.com/keep-network/tbtc-v2.ts": {
@@ -49,6 +50,10 @@
         },
         "github.com/keep-network/tbtc-mg": {
             "workflow": "maintainer.yml",
+            "downstream": []
+        },
+        "github.com/keep-network/cross-chain/arbitrum": {
+            "workflow": "cross-chain-arbitrum.yml",
             "downstream": []
         }
     }

--- a/actions/run-workflow/dist/config.json
+++ b/actions/run-workflow/dist/config.json
@@ -29,7 +29,8 @@
             "workflow": "contracts.yml",
             "downstream": [
                 "github.com/keep-network/keep-core/client",
-                "github.com/keep-network/tbtc-v2.ts"
+                "github.com/keep-network/tbtc-v2.ts",
+                "github.com/keep-network/cross-chain/arbitrum"
             ]
         },
         "github.com/keep-network/tbtc-v2.ts": {
@@ -49,6 +50,10 @@
         },
         "github.com/keep-network/tbtc-mg": {
             "workflow": "maintainer.yml",
+            "downstream": []
+        },
+        "github.com/keep-network/cross-chain/arbitrum": {
+            "workflow": "cross-chain-arbitrum.yml",
             "downstream": []
         }
     }

--- a/actions/upstream-builds-query/dist/config.json
+++ b/actions/upstream-builds-query/dist/config.json
@@ -29,7 +29,8 @@
             "workflow": "contracts.yml",
             "downstream": [
                 "github.com/keep-network/keep-core/client",
-                "github.com/keep-network/tbtc-v2.ts"
+                "github.com/keep-network/tbtc-v2.ts",
+                "github.com/keep-network/cross-chain/arbitrum"
             ]
         },
         "github.com/keep-network/tbtc-v2.ts": {
@@ -49,6 +50,10 @@
         },
         "github.com/keep-network/tbtc-mg": {
             "workflow": "maintainer.yml",
+            "downstream": []
+        },
+        "github.com/keep-network/cross-chain/arbitrum": {
+            "workflow": "cross-chain-arbitrum.yml",
             "downstream": []
         }
     }

--- a/config/config.json
+++ b/config/config.json
@@ -29,7 +29,8 @@
             "workflow": "contracts.yml",
             "downstream": [
                 "github.com/keep-network/keep-core/client",
-                "github.com/keep-network/tbtc-v2.ts"
+                "github.com/keep-network/tbtc-v2.ts",
+                "github.com/keep-network/cross-chain/arbitrum"
             ]
         },
         "github.com/keep-network/tbtc-v2.ts": {
@@ -49,6 +50,10 @@
         },
         "github.com/keep-network/tbtc-mg": {
             "workflow": "maintainer.yml",
+            "downstream": []
+        },
+        "github.com/keep-network/cross-chain/arbitrum": {
+            "workflow": "cross-chain-arbitrum.yml",
             "downstream": []
         }
     }


### PR DESCRIPTION
Added `github.com/keep-network/cross-chain/arbitrum` CI workflow. This workflow will publish a new npm arbitrum package and deploy code to Goerli Arbitrum testnet.

![image](https://user-images.githubusercontent.com/3156420/224309098-316a1bc2-9335-4754-a239-d620223a769f.png)
