### PR TITLE
Changing arbitrum module name

### DIFF
--- a/actions/notify-workflow-completed/dist/config.json
+++ b/actions/notify-workflow-completed/dist/config.json
@@ -30,7 +30,7 @@
             "downstream": [
                 "github.com/keep-network/keep-core/client",
                 "github.com/keep-network/tbtc-v2.ts",
-                "github.com/keep-network/cross-chain/arbitrum"
+                "github.com/keep-network/tbtc-v2/arbitrum"
             ]
         },
         "github.com/keep-network/tbtc-v2.ts": {
@@ -52,7 +52,7 @@
             "workflow": "maintainer.yml",
             "downstream": []
         },
-        "github.com/keep-network/cross-chain/arbitrum": {
+        "github.com/keep-network/tbtc-v2/arbitrum": {
             "workflow": "cross-chain-arbitrum.yml",
             "downstream": []
         }

--- a/actions/run-workflow/dist/config.json
+++ b/actions/run-workflow/dist/config.json
@@ -30,7 +30,7 @@
             "downstream": [
                 "github.com/keep-network/keep-core/client",
                 "github.com/keep-network/tbtc-v2.ts",
-                "github.com/keep-network/cross-chain/arbitrum"
+                "github.com/keep-network/tbtc-v2/arbitrum"
             ]
         },
         "github.com/keep-network/tbtc-v2.ts": {
@@ -52,7 +52,7 @@
             "workflow": "maintainer.yml",
             "downstream": []
         },
-        "github.com/keep-network/cross-chain/arbitrum": {
+        "github.com/keep-network/tbtc-v2/arbitrum": {
             "workflow": "cross-chain-arbitrum.yml",
             "downstream": []
         }

--- a/actions/upstream-builds-query/dist/config.json
+++ b/actions/upstream-builds-query/dist/config.json
@@ -30,7 +30,7 @@
             "downstream": [
                 "github.com/keep-network/keep-core/client",
                 "github.com/keep-network/tbtc-v2.ts",
-                "github.com/keep-network/cross-chain/arbitrum"
+                "github.com/keep-network/tbtc-v2/arbitrum"
             ]
         },
         "github.com/keep-network/tbtc-v2.ts": {
@@ -52,7 +52,7 @@
             "workflow": "maintainer.yml",
             "downstream": []
         },
-        "github.com/keep-network/cross-chain/arbitrum": {
+        "github.com/keep-network/tbtc-v2/arbitrum": {
             "workflow": "cross-chain-arbitrum.yml",
             "downstream": []
         }

--- a/config/config.json
+++ b/config/config.json
@@ -30,7 +30,7 @@
             "downstream": [
                 "github.com/keep-network/keep-core/client",
                 "github.com/keep-network/tbtc-v2.ts",
-                "github.com/keep-network/cross-chain/arbitrum"
+                "github.com/keep-network/tbtc-v2/arbitrum"
             ]
         },
         "github.com/keep-network/tbtc-v2.ts": {
@@ -52,7 +52,7 @@
             "workflow": "maintainer.yml",
             "downstream": []
         },
-        "github.com/keep-network/cross-chain/arbitrum": {
+        "github.com/keep-network/tbtc-v2/arbitrum": {
             "workflow": "cross-chain-arbitrum.yml",
             "downstream": []
         }


### PR DESCRIPTION
Refs https://github.com/keep-network/ci/issues/40

This PR is a followup up PR to this comment https://github.com/keep-network/tbtc-v2/pull/554#discussion_r1133976454 around naming CI modules. 
> first three chunks of the module name need to represent the repository name