### PR TITLE
Ci module names update

### DIFF
--- a/actions/notify-workflow-completed/dist/config.json
+++ b/actions/notify-workflow-completed/dist/config.json
@@ -29,15 +29,15 @@
             "workflow": "contracts.yml",
             "downstream": [
                 "github.com/keep-network/keep-core/client",
-                "github.com/keep-network/tbtc-v2.ts",
+                "github.com/keep-network/tbtc-v2/typescript",
                 "github.com/keep-network/tbtc-v2/arbitrum"
             ]
         },
-        "github.com/keep-network/tbtc-v2.ts": {
+        "github.com/keep-network/tbtc-v2/typescript": {
             "workflow": "typescript.yml",
             "downstream": [
                 "github.com/threshold-network/token-dashboard",
-                "github.com/keep-network/tbtc-mg"
+                "github.com/keep-network/optimistic-minting"
             ]
         },
         "github.com/keep-network/keep-core/client": {
@@ -48,7 +48,7 @@
             "workflow": "dashboard-ci.yml",
             "downstream": []
         },
-        "github.com/keep-network/tbtc-mg": {
+        "github.com/keep-network/optimistic-minting": {
             "workflow": "maintainer.yml",
             "downstream": []
         },

--- a/actions/notify-workflow-completed/dist/config.json
+++ b/actions/notify-workflow-completed/dist/config.json
@@ -30,7 +30,7 @@
             "downstream": [
                 "github.com/keep-network/keep-core/client",
                 "github.com/keep-network/tbtc-v2.ts",
-                "github.com/keep-network/cross-chain/arbitrum"
+                "github.com/keep-network/tbtc-v2/arbitrum"
             ]
         },
         "github.com/keep-network/tbtc-v2.ts": {
@@ -52,7 +52,7 @@
             "workflow": "maintainer.yml",
             "downstream": []
         },
-        "github.com/keep-network/cross-chain/arbitrum": {
+        "github.com/keep-network/tbtc-v2/arbitrum": {
             "workflow": "cross-chain-arbitrum.yml",
             "downstream": []
         }

--- a/actions/run-workflow/dist/config.json
+++ b/actions/run-workflow/dist/config.json
@@ -29,15 +29,15 @@
             "workflow": "contracts.yml",
             "downstream": [
                 "github.com/keep-network/keep-core/client",
-                "github.com/keep-network/tbtc-v2.ts",
+                "github.com/keep-network/tbtc-v2/typescript",
                 "github.com/keep-network/tbtc-v2/arbitrum"
             ]
         },
-        "github.com/keep-network/tbtc-v2.ts": {
+        "github.com/keep-network/tbtc-v2/typescript": {
             "workflow": "typescript.yml",
             "downstream": [
                 "github.com/threshold-network/token-dashboard",
-                "github.com/keep-network/tbtc-mg"
+                "github.com/keep-network/optimistic-minting"
             ]
         },
         "github.com/keep-network/keep-core/client": {
@@ -48,7 +48,7 @@
             "workflow": "dashboard-ci.yml",
             "downstream": []
         },
-        "github.com/keep-network/tbtc-mg": {
+        "github.com/keep-network/optimistic-minting": {
             "workflow": "maintainer.yml",
             "downstream": []
         },

--- a/actions/run-workflow/dist/config.json
+++ b/actions/run-workflow/dist/config.json
@@ -30,7 +30,7 @@
             "downstream": [
                 "github.com/keep-network/keep-core/client",
                 "github.com/keep-network/tbtc-v2.ts",
-                "github.com/keep-network/cross-chain/arbitrum"
+                "github.com/keep-network/tbtc-v2/arbitrum"
             ]
         },
         "github.com/keep-network/tbtc-v2.ts": {
@@ -52,7 +52,7 @@
             "workflow": "maintainer.yml",
             "downstream": []
         },
-        "github.com/keep-network/cross-chain/arbitrum": {
+        "github.com/keep-network/tbtc-v2/arbitrum": {
             "workflow": "cross-chain-arbitrum.yml",
             "downstream": []
         }

--- a/actions/upstream-builds-query/dist/config.json
+++ b/actions/upstream-builds-query/dist/config.json
@@ -29,15 +29,15 @@
             "workflow": "contracts.yml",
             "downstream": [
                 "github.com/keep-network/keep-core/client",
-                "github.com/keep-network/tbtc-v2.ts",
+                "github.com/keep-network/tbtc-v2/typescript",
                 "github.com/keep-network/tbtc-v2/arbitrum"
             ]
         },
-        "github.com/keep-network/tbtc-v2.ts": {
+        "github.com/keep-network/tbtc-v2/typescript": {
             "workflow": "typescript.yml",
             "downstream": [
                 "github.com/threshold-network/token-dashboard",
-                "github.com/keep-network/tbtc-mg"
+                "github.com/keep-network/optimistic-minting"
             ]
         },
         "github.com/keep-network/keep-core/client": {
@@ -48,7 +48,7 @@
             "workflow": "dashboard-ci.yml",
             "downstream": []
         },
-        "github.com/keep-network/tbtc-mg": {
+        "github.com/keep-network/optimistic-minting": {
             "workflow": "maintainer.yml",
             "downstream": []
         },

--- a/actions/upstream-builds-query/dist/config.json
+++ b/actions/upstream-builds-query/dist/config.json
@@ -30,7 +30,7 @@
             "downstream": [
                 "github.com/keep-network/keep-core/client",
                 "github.com/keep-network/tbtc-v2.ts",
-                "github.com/keep-network/cross-chain/arbitrum"
+                "github.com/keep-network/tbtc-v2/arbitrum"
             ]
         },
         "github.com/keep-network/tbtc-v2.ts": {
@@ -52,7 +52,7 @@
             "workflow": "maintainer.yml",
             "downstream": []
         },
-        "github.com/keep-network/cross-chain/arbitrum": {
+        "github.com/keep-network/tbtc-v2/arbitrum": {
             "workflow": "cross-chain-arbitrum.yml",
             "downstream": []
         }

--- a/config/config.json
+++ b/config/config.json
@@ -29,15 +29,15 @@
             "workflow": "contracts.yml",
             "downstream": [
                 "github.com/keep-network/keep-core/client",
-                "github.com/keep-network/tbtc-v2.ts",
+                "github.com/keep-network/tbtc-v2/typescript",
                 "github.com/keep-network/tbtc-v2/arbitrum"
             ]
         },
-        "github.com/keep-network/tbtc-v2.ts": {
+        "github.com/keep-network/tbtc-v2/typescript": {
             "workflow": "typescript.yml",
             "downstream": [
                 "github.com/threshold-network/token-dashboard",
-                "github.com/keep-network/tbtc-mg"
+                "github.com/keep-network/optimistic-minting"
             ]
         },
         "github.com/keep-network/keep-core/client": {
@@ -48,7 +48,7 @@
             "workflow": "dashboard-ci.yml",
             "downstream": []
         },
-        "github.com/keep-network/tbtc-mg": {
+        "github.com/keep-network/optimistic-minting": {
             "workflow": "maintainer.yml",
             "downstream": []
         },

--- a/config/config.json
+++ b/config/config.json
@@ -30,7 +30,7 @@
             "downstream": [
                 "github.com/keep-network/keep-core/client",
                 "github.com/keep-network/tbtc-v2.ts",
-                "github.com/keep-network/cross-chain/arbitrum"
+                "github.com/keep-network/tbtc-v2/arbitrum"
             ]
         },
         "github.com/keep-network/tbtc-v2.ts": {
@@ -52,7 +52,7 @@
             "workflow": "maintainer.yml",
             "downstream": []
         },
-        "github.com/keep-network/cross-chain/arbitrum": {
+        "github.com/keep-network/tbtc-v2/arbitrum": {
             "workflow": "cross-chain-arbitrum.yml",
             "downstream": []
         }


### PR DESCRIPTION
Branched off of https://github.com/keep-network/ci/pull/41, so it has a dependency on it.

Changes in module names as per this comment https://github.com/keep-network/ci/pull/41#pullrequestreview-1340841422

TODO after the merge:

- [ ] refresh the `v2` tag