### PR TITLE
Fix extracting of org from org/repo name in workflow generating docs

### DIFF
--- a/.github/workflows/reusable-solidity-docs.yml
+++ b/.github/workflows/reusable-solidity-docs.yml
@@ -253,7 +253,7 @@ jobs:
               echo "▶ Push commit"
                 git push --set-upstream origin HEAD:$head_branch
               echo "▶ Check if PR for the head branch already exists"
-                dest_org=${${{ inputs.destinationRepo }}%%/*}
+              dest_org=$(echo ${{ inputs.destinationRepo }} | cut -d'/' -f1)
                 pr_for_head=$(curl -L \
                   -H "Accept: application/vnd.github+json" \
                   -H "Authorization: Bearer $API_TOKEN_GITHUB" \


### PR DESCRIPTION
Previously we've used `dest_org=${${{ inputs.destinationRepo }}%%/*}` which was removing the longest part (separated by `/`) from the input. This wasn't what we wanted in cases where the org name is longer than the repo name. We're now changing the approach and we're using `dest_org=$(echo ${{ inputs.destinationRepo }} | cut -d'/' -f1)` command now. The `cut` command is used to extract sections from lines of files or strings. In this case, we're using it to split the ${{ inputs.destinationRepo }} string on the `/` delimiter and then selecting the first field (`-f1`) before the delimiter. By using this approach, it doesn't matter if the first or second part is longer; it will always extract the first part of the variable containing `/`.