### PR TITLE
Remove `typescript` (and `optimistic-minting`) modules from the CI flow

### DIFF
--- a/actions/notify-workflow-completed/dist/config.json
+++ b/actions/notify-workflow-completed/dist/config.json
@@ -29,15 +29,8 @@
             "workflow": "contracts.yml",
             "downstream": [
                 "github.com/keep-network/keep-core/client",
-                "github.com/keep-network/tbtc-v2/typescript",
-                "github.com/keep-network/tbtc-v2/arbitrum"
-            ]
-        },
-        "github.com/keep-network/tbtc-v2/typescript": {
-            "workflow": "typescript.yml",
-            "downstream": [
                 "github.com/threshold-network/token-dashboard",
-                "github.com/keep-network/optimistic-minting"
+                "github.com/keep-network/tbtc-v2/arbitrum"
             ]
         },
         "github.com/keep-network/keep-core/client": {
@@ -46,10 +39,6 @@
         },
         "github.com/threshold-network/token-dashboard": {
             "workflow": "dashboard-ci.yml",
-            "downstream": []
-        },
-        "github.com/keep-network/optimistic-minting": {
-            "workflow": "maintainer.yml",
             "downstream": []
         },
         "github.com/keep-network/tbtc-v2/arbitrum": {

--- a/actions/run-workflow/dist/config.json
+++ b/actions/run-workflow/dist/config.json
@@ -29,15 +29,8 @@
             "workflow": "contracts.yml",
             "downstream": [
                 "github.com/keep-network/keep-core/client",
-                "github.com/keep-network/tbtc-v2/typescript",
-                "github.com/keep-network/tbtc-v2/arbitrum"
-            ]
-        },
-        "github.com/keep-network/tbtc-v2/typescript": {
-            "workflow": "typescript.yml",
-            "downstream": [
                 "github.com/threshold-network/token-dashboard",
-                "github.com/keep-network/optimistic-minting"
+                "github.com/keep-network/tbtc-v2/arbitrum"
             ]
         },
         "github.com/keep-network/keep-core/client": {
@@ -46,10 +39,6 @@
         },
         "github.com/threshold-network/token-dashboard": {
             "workflow": "dashboard-ci.yml",
-            "downstream": []
-        },
-        "github.com/keep-network/optimistic-minting": {
-            "workflow": "maintainer.yml",
             "downstream": []
         },
         "github.com/keep-network/tbtc-v2/arbitrum": {

--- a/actions/upstream-builds-query/dist/config.json
+++ b/actions/upstream-builds-query/dist/config.json
@@ -29,15 +29,8 @@
             "workflow": "contracts.yml",
             "downstream": [
                 "github.com/keep-network/keep-core/client",
-                "github.com/keep-network/tbtc-v2/typescript",
-                "github.com/keep-network/tbtc-v2/arbitrum"
-            ]
-        },
-        "github.com/keep-network/tbtc-v2/typescript": {
-            "workflow": "typescript.yml",
-            "downstream": [
                 "github.com/threshold-network/token-dashboard",
-                "github.com/keep-network/optimistic-minting"
+                "github.com/keep-network/tbtc-v2/arbitrum"
             ]
         },
         "github.com/keep-network/keep-core/client": {
@@ -46,10 +39,6 @@
         },
         "github.com/threshold-network/token-dashboard": {
             "workflow": "dashboard-ci.yml",
-            "downstream": []
-        },
-        "github.com/keep-network/optimistic-minting": {
-            "workflow": "maintainer.yml",
             "downstream": []
         },
         "github.com/keep-network/tbtc-v2/arbitrum": {

--- a/config/config.json
+++ b/config/config.json
@@ -29,15 +29,8 @@
             "workflow": "contracts.yml",
             "downstream": [
                 "github.com/keep-network/keep-core/client",
-                "github.com/keep-network/tbtc-v2/typescript",
-                "github.com/keep-network/tbtc-v2/arbitrum"
-            ]
-        },
-        "github.com/keep-network/tbtc-v2/typescript": {
-            "workflow": "typescript.yml",
-            "downstream": [
                 "github.com/threshold-network/token-dashboard",
-                "github.com/keep-network/optimistic-minting"
+                "github.com/keep-network/tbtc-v2/arbitrum"
             ]
         },
         "github.com/keep-network/keep-core/client": {
@@ -46,10 +39,6 @@
         },
         "github.com/threshold-network/token-dashboard": {
             "workflow": "dashboard-ci.yml",
-            "downstream": []
-        },
-        "github.com/keep-network/optimistic-minting": {
-            "workflow": "maintainer.yml",
             "downstream": []
         },
         "github.com/keep-network/tbtc-v2/arbitrum": {


### PR DESCRIPTION
We no longer want to publish new `typescript` testnet packages as part of the CI flow. The `typescript` project is transitioning to v2, which has all the chain configs embeded, so we'll no longer use the `mainnet` and `goerli` packages. All existing testnet packages were marked in the NPM registry as deprecated (projects still can use them as dependencies, but will get a warning).

After the changes, the flow will look like this:
![image](https://github.com/keep-network/ci/assets/78352137/3832784c-6450-4bda-bf08-169c4811c19b)
