### PR TITLE
Update actions to versions running on Node20

### DIFF
--- a/.github/workflows/load-env-variables.yml
+++ b/.github/workflows/load-env-variables.yml
@@ -19,7 +19,7 @@ jobs:
   load-env-variables-manual-test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Load environment variables
         uses: ./actions/load-env-variables

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,7 @@ jobs:
   run-release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Invoke downstream workflows
         uses: keep-network/ci/actions/run-workflow@v2

--- a/.github/workflows/reusable-solidity-docs.yml
+++ b/.github/workflows/reusable-solidity-docs.yml
@@ -141,7 +141,7 @@ jobs:
       run:
         working-directory: .${{ inputs.projectDir }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       # In this step we modify the format of the comments in the Solidity
       # contracts files. We do that because our original formatting is not
@@ -181,7 +181,7 @@ jobs:
         shell: bash
         run: git config --global url."https://".insteadOf git://
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           # Using fixed version, because 18.16 was sometimes causing issues with
           # artifacts generation during `hardhat compile` - see
@@ -221,7 +221,7 @@ jobs:
           inputs.exportAsGHArtifacts == true
             && inputs.commentPR == true
             && startsWith(github.ref, 'refs/pull')
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           script: |
             github.rest.issues.createComment({
@@ -233,7 +233,7 @@ jobs:
 
       - name: Import GPG key
         if: inputs.publish == true && inputs.verifyCommits == true
-        uses: crazy-max/ghaction-import-gpg@111c56156bcc6918c056dbef52164cfa583dc549 # v5.2.0
+        uses: crazy-max/ghaction-import-gpg@01dd5d3ca463c7f10f7f4f7b4f177225ac661ee4 # v6.1.0
         with:
           gpg_private_key: ${{ secrets.gpgPrivateKey }}
           passphrase: ${{ secrets.gpgPassphrase }}

--- a/.github/workflows/tools.yml
+++ b/.github/workflows/tools.yml
@@ -10,12 +10,12 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: yarn install
       - run: yarn run test
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: yarn install
       - run: yarn run lint

--- a/.github/workflows/upstream-builds-query.yml
+++ b/.github/workflows/upstream-builds-query.yml
@@ -20,11 +20,11 @@ jobs:
     name: Verify committed dist directory
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           persist-credentials: false
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: "12"
 
@@ -50,11 +50,11 @@ jobs:
   upstream-builds-query-unit-tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           persist-credentials: false
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: "12"
 
@@ -65,7 +65,7 @@ jobs:
   upstream-builds-query-e2e-test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: ./actions/upstream-builds-query
         id: upstream-builds-query

--- a/actions/notify-workflow-completed/action.yml
+++ b/actions/notify-workflow-completed/action.yml
@@ -27,5 +27,5 @@ branding:
   icon: "rotate-ccw"
 
 runs:
-  using: node16
+  using: node20
   main: "./dist/index.js"

--- a/actions/run-workflow/action.yml
+++ b/actions/run-workflow/action.yml
@@ -18,5 +18,5 @@ branding:
   icon: "wind"
 
 runs:
-  using: "node16"
+  using: "node20"
   main: "./dist/index.js"

--- a/actions/upstream-builds-query/action.yml
+++ b/actions/upstream-builds-query/action.yml
@@ -17,7 +17,7 @@ outputs:
     description: ""
 
 runs:
-  using: node16
+  using: node20
   main: "./dist/index.js"
 
 branding:


### PR DESCRIPTION
As per
https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/, GitHub has started a deprecation process for the GitHub Actions that run on Node16. We're updating Actions that use this version of Node to newer versions, running on Node20.