### PR TITLE
Update CI and docs mentioning Ropsten testnet

### DIFF
--- a/.github/workflows/load-env-variables.yml
+++ b/.github/workflows/load-env-variables.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Load environment variables
         uses: ./actions/load-env-variables
         with:
-          environment: 'ropsten'
+          environment: 'sepolia'
           ref: 'main'
 
       - name: Use imported variables

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,7 @@ on:
       environment:
         description: 'The environment to run the build for'
         required: false
-        default: 'ropsten'
+        default: 'sepolia'
       upstream_builds:
         description: 'Upstream builds, if empty runs a default workflow'
         required: false

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ To trigger the `Main` workflow, one needs to provide the following four inputs:
 | Label             | Name | Required? | Default value      | Meaning |
 |-------------------|------|-----------|--------------------|--------|
 | Use workflow from |      | Yes       | `Branch: master`   | Specifies which version of the `Main`‘s workflow config file will be used. |
-| The environment to run the build for | `environment` | No | `ropsten` | Specified value will be passed between downstream builds and used for package versioning and dependency management (the provided string will be part of a package's version name). |
+| The environment to run the build for | `environment` | No | `sepolia` | Specified value will be passed between downstream builds and used for package versioning and dependency management (the provided string will be part of a package's version name). |
 | Upstream builds | `upstream_builds` | No | &lt;empty> | A list of upstream builds that should be used for the building of downstream modules. |
 | Ref |`upstream_ref` | No | `master` | Specifies the branch on which the modules will be built. | 
 
@@ -70,10 +70,5 @@ code.
 ## Monitoring
 
 The following tools can be used to monitor state of the code and deployments:
-* [AllTheKeeps for Ropsten](https://allthekeeps.test.keep.network/deposits)
+* [TBTCscan for Sepolia](https://testnet.tbtcscan.com/)
 * [Keep Clients Summary](https://monitoring.test.keep.network/d/3r-BohOMz/keep-clients-summary?orgId=1&refresh=30s)
-* Meercode Dashboards with GitHub Actions results:
-  - [Relay request submitter / Testnet](https://meercode.io/public/list/af470c2ebc0da4a0b0cce2589660781e:f385a85f1b9ca5b44b35b1d61405b8569c4664f6cf41a8e71283d45ff4ff61b8f20f11dbb75d767c51a809ccd2ea06af)
-  - [E2E tests in `local-setup`](https://meercode.io/public/list/acef9c5954837d43d0249f46d8c38306:2f621d7a4bbef9f85bb4430a88ead6d456ebdadbb7df6fb51a0aab7c10ec457031e7b0f0ee6b0408c7654a3a51057998)
-  - [Daily builds and unit tests](https://meercode.io/public/list/a35b93b575273416124a32f8cd9d1d5f:60fde75491810d92b496eed2bb3ce55ec4124ca10a75cb4273dcad863e8f4d94b51fbbbe4cb07ecbfb40fc4edef71464)
-  - [Deployment on Ropsten](https://meercode.io/public/list/41935b8f5ffcabfd0c0d63412547d720:1c3901d698c5c033914774f1cc5b8ffed254357a89c7a59b20f0c909db2141aa3e23b7a2080036f914c66f3f5cd69fdf)

--- a/actions/load-env-variables/README.md
+++ b/actions/load-env-variables/README.md
@@ -20,7 +20,7 @@ The action supports following input parameters:
 ```yaml
       - uses: keep-network/ci/actions/load-env-variables@v1
         with:
-          environment: 'ropsten'
+          environment: 'sepolia'
 ```
 
 ## Configuration of the input file
@@ -30,7 +30,7 @@ repository under `./config/env/` directory. The idea is to have
 separate config files for separate environments.
 
 The name of each file should indicate the name of the environment to which
-the variables' values apply and should have `.env` extension (e.g. `ropsten.env`). 
+the variables' values apply and should have `.env` extension (e.g. `sepolia.env`). 
 
 Variables stored in the file must be written in the `name=value` format.
 
@@ -61,7 +61,7 @@ jobs:
       - name: Load environment variables
         uses: keep-network/ci/actions/load-env-variables@v1
         with:
-          filename: 'ropsten'
+          filename: 'sepolia'
       - name: Use loaded variables
         # Will print "My first variable: first-var".
         run: |

--- a/actions/load-env-variables/action.yml
+++ b/actions/load-env-variables/action.yml
@@ -7,7 +7,7 @@ inputs:
   environment:
     description: >
       Name of the environment indicating which config file will be used for
-      variables import. For example, if "ropsten" provided, "ropsten.env" config
+      variables import. For example, if "sepolia" provided, "sepolia.env" config
       file will be used for variables import.
       Config file of the name <environment>.env must exist in
       keep-network/ci/config/env/ and must contain list of the variables in the


### PR DESCRIPTION
In couple of places we still were mentiong Ropsten testnet which is now deprecated. We're updating those places to mention Sepolia testnet instead. Also we're updating outdated info on the monitoring tools.

Note: PR marked as draft, it was built based on code from https://github.com/keep-network/ci/pull/50.

Ref: https://github.com/threshold-network/solidity-contracts/issues/163